### PR TITLE
set up Go version 1.21 in CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.21
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
## Issue
Closes #94 

## Description
Set Go version to 1.21 in CodeQL action using [setup-go](https://github.com/actions/setup-go)